### PR TITLE
feature/cache-imgur

### DIFF
--- a/kubernetes-deployment.yaml
+++ b/kubernetes-deployment.yaml
@@ -31,7 +31,6 @@ spec:
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
-             path: /ready
+             path: /api/skateparks
              port: 8080
           initialDelaySeconds: 30
-          timeoutSeconds: 5


### PR DESCRIPTION
### Features
- Added a 24 hour cache of the imgur skateparks albums. 
- Updated the readiness probe to hit /api/skateparks to keep the cache alive.